### PR TITLE
Remove scanpy from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ pandas>=1.3.0
 patsy>=0.5.1
 scipy>=1.7.0
 scikit-learn>=0.24
-scanpy==1.7.2
 statsmodels>=0.12.2
 tqdm>=4.61.2


### PR DESCRIPTION
Hi @saketkc, 

Thanks for writing this python implementation of sctransform here! I'm interested in adding a wrapper around this in the [pegasus toolkit](https://github.com/lilab-bcb/pegasus) and I noticed scanpy isn't actually imported anywhere. Is it a required dependency? If not can we remove it?
